### PR TITLE
Let NewRelic see the request URI

### DIFF
--- a/src/io/github/rutledgepaulv/newrelic_clj/internals.clj
+++ b/src/io/github/rutledgepaulv/newrelic_clj/internals.clj
@@ -71,7 +71,9 @@
     (getHeader [name]
       (get-in ring-request [:headers name]))
     (getMethod []
-      (some-> ring-request :request-method name strings/upper-case))))
+      (some-> ring-request :request-method name strings/upper-case))
+    (getRequestURI []
+      (:uri ring-request))))
 
 (defn adapt-ring-response [ring-response]
   (proxy [ExtendedResponse] []


### PR DESCRIPTION
By adding the getRequestURI getter, the request's path shows up correctly in NewRelic under request.uri