### PR TITLE
New Relic 9.0.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 target/
 .nrepl-port
 *.log
+.calva/mcp-server/port
+.clj-kondo/.cache/
+.lsp/.cache/
+.portal/vs-code.edn

--- a/deps.edn
+++ b/deps.edn
@@ -1,27 +1,26 @@
 {:deps
  {com.github.rutledgepaulv/injecting-streams {:mvn/version "2.0"}
-  com.newrelic.agent.java/newrelic-api       {:mvn/version "8.0.1"}
-  ring/ring-core                             {:mvn/version "1.9.6"}
-  org.slf4j/slf4j-api                        {:mvn/version "2.0.6"}}
+  com.newrelic.agent.java/newrelic-api       {:mvn/version "9.0.0"}
+  ring/ring-core                             {:mvn/version "1.15.3"}
+  org.slf4j/slf4j-api                        {:mvn/version "2.0.17"}}
 
  :paths
  ["src"]
 
  :aliases
  {:build {:extra-deps  {io.github.clojure/tools.build
-                        {:git/url "https://github.com/clojure/tools.build.git"
-                         :sha     "75817f39b76375886a9014de3c4b5ab28e9456c8"}}
+                        {:mvn/version "0.10.12"}}
           :extra-paths ["builds"]
           :ns-default  build}
 
   :test  {:extra-paths ["test"]
           :jvm-opts    ["-javaagent:./newrelic/newrelic.jar"]
           :extra-deps  {ring/ring-jetty-adapter
-                        {:mvn/version "1.9.6"}
+                        {:mvn/version "1.15.3"}
                         org.slf4j/slf4j-simple
-                        {:mvn/version "2.0.6"}
+                        {:mvn/version "2.0.17"}
                         io.github.cognitect-labs/test-runner
-                        {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                         :sha     "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
+                        {:git/tag "v0.5.1"
+                         :git/sha "dfb30dd"}}
           :main-opts   ["-m" "cognitect.test-runner"]
           :exec-fn     cognitect.test-runner.api/test}}}

--- a/src/io/github/rutledgepaulv/newrelic_clj/api.clj
+++ b/src/io/github/rutledgepaulv/newrelic_clj/api.clj
@@ -274,22 +274,18 @@
    (fn wrap-rum-injection-handler
      ([request]
       (let [header   (NewRelic/getBrowserTimingHeader)
-            footer   (NewRelic/getBrowserTimingFooter)
             response (handler request)]
-        (if (and (or (not (strings/blank? header))
-                     (not (strings/blank? footer)))
+        (if (and (not (strings/blank? header))
                  (should-inject? response))
-          (inject/perform-injection response header footer)
+          (inject/perform-injection response header)
           response)))
      ([request respond raise]
-      (let [header (NewRelic/getBrowserTimingHeader)
-            footer (NewRelic/getBrowserTimingFooter)]
+      (let [header (NewRelic/getBrowserTimingHeader)]
         (handler request
                  (fn [response]
                    (respond
-                     (if (and (or (not (strings/blank? header))
-                                  (not (strings/blank? footer)))
+                     (if (and (not (strings/blank? header))
                               (should-inject? response))
-                       (inject/perform-injection response header footer)
+                       (inject/perform-injection response header)
                        response)))
                  raise))))))

--- a/test/io/github/rutledgepaulv/newrelic_clj/inject_test.clj
+++ b/test/io/github/rutledgepaulv/newrelic_clj/inject_test.clj
@@ -13,10 +13,9 @@
 
 (deftest content-injection
   (let [header            "<script>console.log('header');</script>"
-        footer            "<script>console.log('footer');</script>"
         original          "<html><head></head><body></body></html>"
         response          {:headers {"Content-Type" "text/html"} :body original}
-        injected-response (perform-injection response header footer)]
+        injected-response (perform-injection response header)]
     (is (satisfies? protos/StreamableResponseBody (:body injected-response)))
-    (is (= (format "<html><head>%s</head><body>%s</body></html>" header footer)
+    (is (= (format "<html><head>%s</head><body></body></html>" header)
            (response-body->string injected-response)))))


### PR DESCRIPTION
Fixes #5 by removing all references to `footer`.

This only changes the rum injection behavior and does not change the actual library API but you might still want this to be a major (or minor) version update, rather than a patch.

I also updated the various deps (and switched `tools.build` and `test-runner` to use actual versions rather than SHAs).